### PR TITLE
Change options watch handler to update values via native Sortable method

### DIFF
--- a/src/components/Sortable.vue
+++ b/src/components/Sortable.vue
@@ -2,26 +2,26 @@
 import { ref, PropType, watch, onUnmounted, computed } from "vue";
 import Sortable, { SortableOptions } from "sortablejs";
 
+type SortableOptionsProp = Omit<
+  SortableOptions,
+  | "onUnchoose"
+  | "onChoose"
+  | "onStart"
+  | "onEnd"
+  | "onAdd"
+  | "onUpdate"
+  | "onSort"
+  | "onRemove"
+  | "onFilter"
+  | "onMove"
+  | "onClone"
+  | "onChange"
+>;
+
 const props = defineProps({
   /** All SortableJS options are supported; events are handled by the `defineEmits` below and should be used with v-on */
   options: {
-    type: Object as PropType<
-      Omit<
-        SortableOptions,
-        | "onUnchoose"
-        | "onChoose"
-        | "onStart"
-        | "onEnd"
-        | "onAdd"
-        | "onUpdate"
-        | "onSort"
-        | "onRemove"
-        | "onFilter"
-        | "onMove"
-        | "onClone"
-        | "onChange"
-      >
-    >,
+    type: Object as PropType<SortableOptionsProp>,
     default: null,
     required: false,
   },
@@ -94,7 +94,12 @@ watch(
   () => props.options,
   (options) => {
     if (options && sortable?.value) {
-      sortable.value.options = { ...sortable.value.options, ...options };
+      for (const property in options) {
+        sortable.value.option(
+          property as keyof SortableOptionsProp,
+          options[property as keyof SortableOptionsProp]
+        );
+      }
     }
   }
 );


### PR DESCRIPTION
The `group` option is manipulated by Sortable to include `checkPut` and `checkPull` methods, when Sortable-vue3 detects options have changed, it overwrites the options property on Sortable directly.

This means you lose `checkPut` and `checkPull` (destructuring is only a shallow merge), causing errors when you try to drag between groups.

![image](https://user-images.githubusercontent.com/30434619/186128151-f76e850c-faf5-4756-b080-7af999f28d5a.png)

To resolve, I've changed the watch handler to use the `option` method on the Sortable object, looping through and updating the values one by one.

This seems to have resolved the issue.

I've also had to move the prop type out into a dedicated type to keep TS happy.