### PR TITLE
Adding Object type as list prop type

### DIFF
--- a/src/components/Sortable.vue
+++ b/src/components/Sortable.vue
@@ -27,7 +27,7 @@ const props = defineProps({
   },
   /** Your list of items **/
   list: {
-    type: Array as PropType<any[]>,
+    type: [Array, Object] as PropType<any[]>,
     default: [],
     required: true,
   },


### PR DESCRIPTION
To avoid a warning error in the console, I added the Object type to list prop.

![image](https://user-images.githubusercontent.com/2923303/191981369-e821f8b2-fddd-4b96-b37a-183cbad70ab9.png)
