### PR TITLE
Added capture modifier support onMove event

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ You can listen to Sortable events by adding the listeners to the `Sortable` comp
   @remove="(event: Sortable.SortableEvent) => void"
   @filter="(event: Sortable.SortableEvent) => void"
   @move="(event: Sortable.MoveEvent, event2: Event) => void"
+  @move.capture="(event: Sortable.MoveEvent, event2: Event) => boolean | -1 | 1"
   @clone="(event: Sortable.SortableEvent) => void"
 >
 ```

--- a/src/components/Sortable.vue
+++ b/src/components/Sortable.vue
@@ -86,7 +86,7 @@ watch(containerRef, (newDraggable) => {
       onSort: (event) => emit("sort", event),
       onRemove: (event) => emit("remove", event),
       onFilter: (event) => emit("filter", event),
-      onMove: (event, originalEvent) => "onMoveCapture" in attrs ? attrs.onMoveCapture() : emit("move", event, originalEvent),
+      onMove: (event, originalEvent) => "onMoveCapture" in attrs ? (<() => void>attrs.onMoveCapture)() : emit("move", event, originalEvent),
       onClone: (event) => emit("clone", event),
       onChange: (event) => emit("change", event),
     });

--- a/src/components/Sortable.vue
+++ b/src/components/Sortable.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, PropType, watch, onUnmounted, computed } from "vue";
+import { ref, PropType, watch, onUnmounted, computed, useAttrs } from "vue";
 import Sortable, { SortableOptions } from "sortablejs";
 import type { AutoScrollOptions } from "sortablejs/plugins";
 
@@ -63,6 +63,8 @@ const emit = defineEmits<{
   (eventName: "change", evt: Sortable.SortableEvent): void;
 }>();
 
+const attrs = useAttrs()
+
 const containerRef = ref<HTMLElement | null>(null);
 const sortable = ref<Sortable | null>(null);
 const getKey = computed(() => {
@@ -84,7 +86,7 @@ watch(containerRef, (newDraggable) => {
       onSort: (event) => emit("sort", event),
       onRemove: (event) => emit("remove", event),
       onFilter: (event) => emit("filter", event),
-      onMove: (event, originalEvent) => emit("move", event, originalEvent),
+      onMove: (event, originalEvent) => "onMoveCapture" in attrs ? attrs.onMoveCapture() : emit("move", event, originalEvent),
       onClone: (event) => emit("clone", event),
       onChange: (event) => emit("change", event),
     });

--- a/src/components/Sortable.vue
+++ b/src/components/Sortable.vue
@@ -86,6 +86,7 @@ watch(containerRef, (newDraggable) => {
       onSort: (event) => emit("sort", event),
       onRemove: (event) => emit("remove", event),
       onFilter: (event) => emit("filter", event),
+      // See https://github.com/MaxLeiter/sortablejs-vue3/pull/56 for context on `attrs`.
       onMove: (event, originalEvent) => "onMoveCapture" in attrs ? (<() => void>attrs.onMoveCapture)() : emit("move", event, originalEvent),
       onClone: (event) => emit("clone", event),
       onChange: (event) => emit("change", event),

--- a/src/components/Sortable.vue
+++ b/src/components/Sortable.vue
@@ -87,7 +87,7 @@ watch(containerRef, (newDraggable) => {
       onRemove: (event) => emit("remove", event),
       onFilter: (event) => emit("filter", event),
       // See https://github.com/MaxLeiter/sortablejs-vue3/pull/56 for context on `attrs`.
-      onMove: (event, originalEvent) => "onMoveCapture" in attrs ? (<() => void>attrs.onMoveCapture)() : emit("move", event, originalEvent),
+      onMove: (event, originalEvent) => "onMoveCapture" in attrs ? (<(event: Sortable.MoveEvent, originalEvent: Event) => void>attrs.onMoveCapture)(event, originalEvent) : emit("move", event, originalEvent),
       onClone: (event) => emit("clone", event),
       onChange: (event) => emit("change", event),
     });


### PR DESCRIPTION
Now added support for returning values on onMove method.
```
<Sortable item-key="id" :list="items" @move.capture="onMove">
  <template #item="{element, index}">
    <div class="draggable" :key="element.id">
      {{ element.value }}
    </div>
  </template>
</Sortable>
```
```
<script lang="ts" setup>
// now we can return next values to realize some logic 
function onMove() {
  // return false; — for cancel
  // return -1; — insert before target
  // return 1; — insert after target
  // return true; — keep default insertion point based on the direction
  // return void; — keep default insertion point based on the direction
  return false
}
</script>
```