### PR TITLE
Ignore readme files in build

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -31,4 +31,4 @@ sortablejs-*.tgz
 # Specific to ignoring when packaging
 .github
 
-
+readme


### PR DESCRIPTION
Hey there! In the npm build the `readme/demo.gif` file is present, which makes no sense.
This commit adds the full `readme` directory to the list of npm-ignored paths.

I also saw that you explicitly whitelisted the `.vscode/extensions.json` in the npm build, why is that?