### PR TITLE
chore: use vue-demi for backward compat with vue2

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ![GIF of the demo being used](./readme/demo.gif)
 
-This is a thin wrapper around the great [SortableJS](https://github.com/SortableJS/Sortable) library. I had many issues migrating from Vue.Draggable to vue.draggable.next, and after briefly investigating I decided that it was too complicated and a smaller solution was the answer. This wrapper attempts to keep you as close to Sortable as possible.
+This is a thin wrapper around the great [SortableJS](https://github.com/SortableJS/Sortable) library for Vue 2 & 3. I had many issues migrating from Vue.Draggable to vue.draggable.next, and after briefly investigating I decided that it was too complicated and a smaller solution was the answer. This wrapper attempts to keep you as close to Sortable as possible.
 
 ### Why not use \<other library\>?
 
@@ -123,6 +123,14 @@ onEnd(event) { moveItemInArray(store.state.items, event.oldIndex, event.newIndex
 ```
 
 You may also want to see the SortableJS store documentation [here](https://github.com/SortableJS/Sortable#store).
+
+## Vue 2 support
+
+If you are using version prior to `vue@2.7.0`, `@vue/composition-api` is required to be installed to use SortableJS-vue3 with Vue 2.
+
+Everything else should be similar to the example above for Vue 3.
+
+Under the hood, we use [Vue Demi](https://github.com/vueuse/vue-demi) a tool that allows us to write Universal Vue Libraries for Vue 2 & 3.
 
 ## Development
 

--- a/package.json
+++ b/package.json
@@ -36,11 +36,17 @@
   },
   "dependencies": {
     "sortablejs": "^1.15.0",
-    "vue": "^3.2.37"
+    "vue": "^3.2.37",
+    "vue-demi": "latest"
   },
   "peerDependencies": {
     "sortablejs": "^1.15.0",
-    "vue": "^3.2.25"
+    "vue": "^2.0.0 || >=3.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@vue/composition-api": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@types/node": "18.11.18",
@@ -50,6 +56,7 @@
     "terser": "5.16.1",
     "typescript": "4.9.4",
     "vite": "4.0.4",
+    "vue": "^3.2.37",
     "vue-tsc": "1.0.21"
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "sortablejs": "^1.15.0",
     "vue": "^3.2.37",
-    "vue-demi": "latest"
+    "vue-demi": "^0.13.11"
   },
   "peerDependencies": {
     "sortablejs": "^1.15.0",
@@ -56,7 +56,6 @@
     "terser": "5.16.1",
     "typescript": "4.9.4",
     "vite": "4.0.4",
-    "vue": "^3.2.37",
     "vue-tsc": "1.0.21"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ specifiers:
   typescript: 4.9.4
   vite: 4.0.4
   vue: ^3.2.37
-  vue-demi: latest
+  vue-demi: ^0.13.11
   vue-tsc: 1.0.21
 
 dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,11 +10,13 @@ specifiers:
   typescript: 4.9.4
   vite: 4.0.4
   vue: ^3.2.37
+  vue-demi: latest
   vue-tsc: 1.0.21
 
 dependencies:
   sortablejs: 1.15.0
   vue: 3.2.41
+  vue-demi: 0.13.11_vue@3.2.41
 
 devDependencies:
   '@types/node': 18.11.18
@@ -710,6 +712,21 @@ packages:
     optionalDependencies:
       fsevents: 2.3.2
     dev: true
+
+  /vue-demi/0.13.11_vue@3.2.41:
+    resolution: {integrity: sha512-IR8HoEEGM65YY3ZJYAjMlKygDQn25D5ajNFNoKh9RSDMQtlzCxtfQjdQgv9jjK+m3377SsJXY8ysq8kLCZL25A==}
+    engines: {node: '>=12'}
+    hasBin: true
+    requiresBuild: true
+    peerDependencies:
+      '@vue/composition-api': ^1.0.0-rc.1
+      vue: ^3.0.0-0 || ^2.6.0
+    peerDependenciesMeta:
+      '@vue/composition-api':
+        optional: true
+    dependencies:
+      vue: 3.2.41
+    dev: false
 
   /vue-template-compiler/2.7.14:
     resolution: {integrity: sha512-zyA5Y3ArvVG0NacJDkkzJuPQDF8RFeRlzV2vLeSnhSpieO6LK2OVbdLPi5MPPs09Ii+gMO8nY4S3iKQxBxDmWQ==}

--- a/src/components/HelloWorld.vue
+++ b/src/components/HelloWorld.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import Sortable from "./Sortable.vue";
-import { computed, ref } from "vue";
+import { computed, ref } from "vue-demi";
 import type { SortableOptions } from "sortablejs";
 import type { AutoScrollOptions } from "sortablejs/plugins";
 

--- a/src/components/Sortable.vue
+++ b/src/components/Sortable.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, PropType, watch, onUnmounted, computed, useAttrs, Ref } from "vue";
+import { ref, PropType, watch, onUnmounted, computed, useAttrs, Ref } from "vue-demi";
 import Sortable, { SortableOptions } from "sortablejs";
 import type { AutoScrollOptions } from "sortablejs/plugins";
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { createApp } from "vue";
+import { createApp } from "vue-demi";
 import App from "./App.vue";
 
 createApp(App).mount("#app");

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,6 +10,9 @@ export default defineConfig({
     preserveSymlinks: false,
   },
   logLevel: "info",
+  optimizeDeps: {
+    exclude: ['vue-demi']
+  },
   build: {
     target: "esnext",
     minify: "terser",


### PR DESCRIPTION
Use vue-demi - https://github.com/MaxLeiter/sortablejs-vue3/issues/69 