### PR TITLE
Add exports.types to tsconfig.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "module": "./dist/sortablejs-vue3.es.js",
   "exports": {
     ".": {
+      "types": "./dist/types/main.d.ts",
       "import": "./dist/sortablejs-vue3.es.js",
       "require": "./dist/sortablejs-vue3.umd.js"
     }


### PR DESCRIPTION
This fixes the import error when using `"moduleResolution": "bundler"` (now the default in Vue)

See https://github.com/vuejs/tsconfig#migrating-from-typescript--50