### PR TITLE
Make all site colors super wacky

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
     />
     <meta name="robots" content="index, follow" />
   </head>
-  <body>
+  <body style="margin: 0; background: #ff00ff;">
     <div id="app"></div>
     <script type="module" src="/src/main.ts"></script>
   </body>

--- a/src/App.vue
+++ b/src/App.vue
@@ -80,29 +80,31 @@ import HelloWorld from "./components/HelloWorld.vue";
 
 <style>
 :root {
-  --link: hsl(215, 49%, 49%);
+  --link: hsl(320, 100%, 60%);
   --gap: 8px;
   --gap-half: calc(var(--gap) / 2);
   --gap-quarter: calc(var(--gap) / 4);
   --gap-double: calc(var(--gap) * 2);
   --content-width: 800px;
 
-  --fg: #2c3e50;
-  --bg: #ecf0f1;
-  --bg-emphasis: #f5f7fa;
+  --fg: #ff00ff;
+  --bg: #0ff0a0;
+  --bg-emphasis: #ffe600;
 
-  --border: #ccc;
+  --border: #ff6600;
   --border-radius: 4px;
 }
 
 #app {
-  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-    Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
+  font-family: "Comic Sans MS", "Chalkboard SE", "Comic Neue", cursive, system-ui, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   color: var(--fg);
   margin: 0 auto;
   max-width: var(--content-width);
+  background: linear-gradient(135deg, #0ff0a0 0%, #ff00ff 25%, #00ffff 50%, #ffe600 75%, #ff6600 100%);
+  min-height: 100vh;
+  padding: 20px;
 }
 
 #app .instructions {
@@ -179,7 +181,7 @@ import HelloWorld from "./components/HelloWorld.vue";
   bottom: 0;
   /* offset the 90% */
   left: 5%;
-  background-color: hsl(215, 83%, 67%);
+  background-color: #ff0000;
   transform-origin: bottom right;
 }
 

--- a/src/components/HelloWorld.vue
+++ b/src/components/HelloWorld.vue
@@ -144,21 +144,27 @@ main {
 }
 
 .draggable {
-  background: #fff;
+  background: linear-gradient(90deg, #ff0066, #ffcc00, #00ffcc);
   padding: 10px;
   margin: 10px;
-  border: 1px solid #ccc;
+  border: 3px solid #ff00ff;
   cursor: move;
+  color: #0000ff;
+  font-weight: bold;
+  text-shadow: 1px 1px 0 #fff;
+  border-radius: 12px;
+  box-shadow: 4px 4px 0 #ff6600;
 }
 
 .ghost {
   opacity: 0.5;
-  background: #fff;
-  border: 1px dashed #ccc;
+  background: #00ff00;
+  border: 3px dashed #ff0000;
 }
 
 .drag {
-  background: #f5f5f5;
+  background: #ff00ff;
+  color: #00ff00;
 }
 
 .wrapper {

--- a/src/examples/WithStore.vue
+++ b/src/examples/WithStore.vue
@@ -131,21 +131,27 @@ main {
 }
 
 .draggable {
-    background: #fff;
+    background: linear-gradient(90deg, #00ffcc, #ff0066, #ffe600);
     padding: 10px;
     margin: 10px;
-    border: 1px solid #ccc;
+    border: 3px solid #00ff00;
     cursor: move;
+    color: #0000ff;
+    font-weight: bold;
+    text-shadow: 1px 1px 0 #fff;
+    border-radius: 12px;
+    box-shadow: 4px 4px 0 #ff00ff;
 }
 
 .ghost {
     opacity: 0.5;
-    background: #fff;
-    border: 1px dashed #ccc;
+    background: #ff6600;
+    border: 3px dashed #00ffff;
 }
 
 .drag {
-    background: #f5f5f5;
+    background: #00ff00;
+    color: #ff0000;
 }
 
 .wrapper {


### PR DESCRIPTION
The sortablejs-vue3 demo site colors have been cranked to maximum wackiness.

### What changed
- Swapped the `:root` CSS variables to neon magenta text, green background, yellow emphasis, and hot orange borders
- Added a rainbow gradient background on `#app` and switched the font to Comic Sans
- Draggable items now have rainbow gradient backgrounds, magenta/green borders, blue text with white text-shadow, rounded corners, and colored box-shadows
- Ghost and drag states use clashing neon colors (lime green, hot pink, red dashes)
- Body background set to magenta
- Applied matching wacky styles to the WithStore example

<a href="https://slack.com/archives/C06S42QMC6M/p1770969855785139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://v0.app/chat-static/slack-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://v0.app/chat-static/slack-light.svg"><img alt="Slack Thread" src="https://v0.app/chat-static/slack-light.svg" width="108" height="30"></picture></a>